### PR TITLE
Bugfix: Spec shorthand

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Examples:
 #### Tests
 This option will modify the extensions being searched for by adding `.spec` before the selected
 options.
-To use this option you can add `--spec` or through the shorthanded notation `-sp`.
+To use this option you can add `--spec` or through the shorthanded notation `-e`.
 
 Examples:
 - `biotope-quality-gate lint --spec` - will lint files with the extensions `.spec.ts` and `.spec.js`

--- a/src/actions/lint.ts
+++ b/src/actions/lint.ts
@@ -133,5 +133,5 @@ export const registerLint: Action = program => program
   .option('-x, --include-jsx', 'Include jsx files (*.?sx)')
   .option('-s, --sass', 'Include sass files (*.scss)')
   .option('-f, --fix', 'Try to fix any erros found')
-  .option('-sp, --spec', 'Specify that the files being linted are tests (*.spec.*)')
+  .option('-e, --spec', 'Specify that the files being linted are tests (*.spec.*)')
   .action(lint);


### PR DESCRIPTION
When using the shorthand `-sp`, the option to lint test files is ignored.
To better understand the bug, undo the last commit (https://github.com/biotope/biotope-quality-gate/commit/5c2bcf952080832063245621ee432504f2c7d9b1) and run the application with `-sp` and `--spec` - the behaviour should be the same, but is not.

As for the actual change to `-e`, it was done as `s` (style/sass), `p` (pattern) and `t` (typescript) are already taken and IMO match their respective functions better.
