### PR TITLE
refactor: 💡 Do not fail on warning

### DIFF
--- a/src/api/report.ts
+++ b/src/api/report.ts
@@ -61,8 +61,8 @@ const reportStyle = (report: Stylelint.LinterResult, projectPath: string, logger
 const hasAnyErrors = (results: ErrorContainer[]): boolean => results.reduce(
   (
     value: boolean,
-    { errorCount, warningCount, errored }: ErrorContainer,
-  ): boolean => value || !!errorCount || !!warningCount || !!errored,
+    { errorCount, errored }: ErrorContainer,
+  ): boolean => value || !!errorCount || !!errored,
   false,
 );
 


### PR DESCRIPTION
Currently when have warnings, the linter is failing and the process is exiting with -1.

I do not want a linter to fail on warnings. That's why there is the difference between warning and error.